### PR TITLE
fix: update script using exec dir rather than cwd

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,15 +30,15 @@ runs:
     - name: Run macOS script
       if: runner.os == 'macOS'
       shell: bash
-      run: ./entrypoint-macos.sh
+      run: entrypoint-macos.sh
 
     - name: Run Linux script
       if: runner.os == 'Linux'
       shell: bash
-      run: ./entrypoint-linux.sh
+      run: entrypoint-linux.sh
 
     - name: Run Windows script
       if: runner.os == 'Windows'
       shell: pwsh
-      run: ./entrypoint.ps1
+      run: powershell.exe -File entrypoint.ps1
 


### PR DESCRIPTION
This removes the CWD denotation (`.`) from the action command.

According to the [composite docs](https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action) and [stackoverflow](https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action), this _should_ fix the "missing script" issue.

fix #3