### PR TITLE
Add connection verification to tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+end_of_line = lf
+
+[*.sh]
+max_line_length = off
+
+[*.ps1]
+max_line_length = off
+
+

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -3,20 +3,19 @@ name: Test MySQL on Ubuntu
 on:
   push:
     paths:
-      - 'entrypoint-linux.sh'
-      - 'action.yml'
+      - "entrypoint-linux.sh"
+      - "action.yml"
   pull_request:
     paths:
-      - 'entrypoint-linux.sh'
-      - 'action.yml'
+      - "entrypoint-linux.sh"
+      - "action.yml"
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 
 jobs:
   test-linux:
@@ -35,4 +34,12 @@ jobs:
           mysql_port: 3307
           mysql_database: my_test_db
           mysql_user: my_user
-          mysql_password: my_user_pass
+          mysql_password:
+      - name: Verify Admin Socket Connection
+        run: mysql -h 127.0.0.1 -P ${{github.env.mysql_port}} -u root -p ${{github.env.mysql_root_password}} -e "SELECT VERSION();"
+      - name: Verify Admin TCP Connection
+        run: mysql -h 127.0.0.1 -P ${{github.env.mysql_port}} -u root -p ${{github.env.mysql_root_password}} -e "SELECT VERSION();" --protocol=TCP
+      - name: Verify User Socket Connection
+        run: mysql -h 127.0.0.1 -P ${{github.env.mysql_port}} -u ${{github.env.my_user}} -p ${{github.env.mysql_password}} -e "SELECT VERSION();"
+      - name: Verify User TCP Connection
+        run: mysql -h 127.0.0.1 -P ${{github.env.mysql_port}} -u ${{github.env.my_user}} -p ${{github.env.mysql_password}} -e "SELECT VERSION();" --protocol=TCP

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -34,7 +34,7 @@ jobs:
           mysql_port: 3307
           mysql_database: my_test_db
           mysql_user: my_user
-          mysql_password:
+          mysql_password: my_user_pass
       - name: Verify Admin Socket Connection
         run: mysql -h 127.0.0.1 -P ${{github.env.mysql_port}} -u root -p ${{github.env.mysql_root_password}} -e "SELECT VERSION();"
       - name: Verify Admin TCP Connection

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -3,15 +3,15 @@ name: Test MySQL on macOS
 on:
   push:
     paths:
-      - 'entrypoint-macos.sh'
-      - 'action.yml'
+      - "entrypoint-macos.sh"
+      - "action.yml"
   pull_request:
     paths:
-      - 'entrypoint-macos.sh'
-      - 'action.yml'
+      - "entrypoint-macos.sh"
+      - "action.yml"
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -35,3 +35,11 @@ jobs:
           mysql_database: my_test_db
           mysql_user: my_user
           mysql_password: my_user_pass
+      - name: Verify Admin Socket Connection
+        run: mysql -h 127.0.0.1 -P ${{github.env.mysql_port}} -u root -p ${{github.env.mysql_root_password}} -e "SELECT VERSION();"
+      - name: Verify Admin TCP Connection
+        run: mysql -h 127.0.0.1 -P ${{github.env.mysql_port}} -u root -p ${{github.env.mysql_root_password}} -e "SELECT VERSION();" --protocol=TCP
+      - name: Verify User Socket Connection
+        run: mysql -h 127.0.0.1 -P ${{github.env.mysql_port}} -u ${{github.env.my_user}} -p ${{github.env.mysql_password}} -e "SELECT VERSION();"
+      - name: Verify User TCP Connection
+        run: mysql -h 127.0.0.1 -P ${{github.env.mysql_port}} -u ${{github.env.my_user}} -p ${{github.env.mysql_password}} -e "SELECT VERSION();" --protocol=TCP

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -3,15 +3,15 @@ name: Test MySQL on Windows
 on:
   push:
     paths:
-      - 'entrypoint.ps1'
-      - 'action.yml'
+      - "entrypoint.ps1"
+      - "action.yml"
   pull_request:
     paths:
-      - 'entrypoint.ps1'
-      - 'action.yml'
+      - "entrypoint.ps1"
+      - "action.yml"
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   test-windows:
@@ -27,3 +27,11 @@ jobs:
           mysql_database: my_db
           mysql_user: my_user
           mysql_password: my_pass
+      - name: Verify Admin Socket Connection
+        run: mysql -h 127.0.0.1 -P ${{github.env.mysql_port}} -u root -p ${{github.env.mysql_root_password}} -e "SELECT VERSION();"
+      - name: Verify Admin TCP Connection
+        run: mysql -h 127.0.0.1 -P ${{github.env.mysql_port}} -u root -p ${{github.env.mysql_root_password}} -e "SELECT VERSION();" --protocol=TCP
+      - name: Verify User Socket Connection
+        run: mysql -h 127.0.0.1 -P ${{github.env.mysql_port}} -u ${{github.env.my_user}} -p ${{github.env.mysql_password}} -e "SELECT VERSION();"
+      - name: Verify User TCP Connection
+        run: mysql -h 127.0.0.1 -P ${{github.env.mysql_port}} -u ${{github.env.my_user}} -p ${{github.env.mysql_password}} -e "SELECT VERSION();" --protocol=TCP


### PR DESCRIPTION
## Changelog

- Add connection verification to the tests to ensure this workflow actually keeps a MySQL server up for the end-user.
   - Note: While there is a small connection test done in the end-user action, but this is not sufficient to emulate a "user environment" 
- Add an `.editorconfig` file to ensure that anyone PRing will have the same file formatting as the original codebase.